### PR TITLE
docs: add Platform-Docs cross-references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main, master]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [main, master]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   ci:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to Metered-SaaS-Logic
+
+Thank you for your interest in contributing!
+
+## Cross-Cutting Decisions
+
+> **⚠️ Important:** All decisions that affect multiple repositories or have platform-wide implications **must** be recorded in [**Platform-Docs**](https://github.com/vindicta-platform/Platform-Docs) before implementation.
+
+This includes:
+- API contract changes
+- Shared schema modifications
+- Authentication/authorization changes
+- New inter-service dependencies
+- Platform-wide configuration changes
+
+See the [Platform-Docs Contributing Guide](https://github.com/vindicta-platform/Platform-Docs/blob/main/CONTRIBUTING.md) for the full process.
+
+## Repo-Specific Guidelines
+
+1. Follow existing code style and conventions
+2. Write tests for new functionality
+3. Keep PRs focused and atomic
+4. Reference related [Platform-Docs proposals](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs/proposals) when applicable

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ print(f"Remaining: {meter.remaining_credits}")
 | [Atomic-Ledger-Py](https://github.com/vindicta-platform/Atomic-Ledger-Py) | Transaction ledger |
 | [platform-core](https://github.com/vindicta-platform/platform-core) | Gas Tank economy |
 
+## Platform Documentation
+
+> **📌 Important:** All cross-cutting decisions, feature proposals, and platform-wide architecture documentation live in [**Platform-Docs**](https://github.com/vindicta-platform/Platform-Docs).
+>
+> Any decision affecting multiple repos **must** be recorded there before implementation.
+
+- 📋 [Feature Proposals](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs/proposals)
+- 🏗️ [Architecture Decisions](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs)
+- 📖 [Contributing Guide](https://github.com/vindicta-platform/Platform-Docs/blob/main/CONTRIBUTING.md)
+
 ## License
 
 MIT License - See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Summary

Adds cross-references to [Platform-Docs](https://github.com/vindicta-platform/Platform-Docs) as the canonical source of truth for cross-cutting decisions, feature proposals, and platform-wide documentation.

### Changes
- **README.md**: Added `## Platform Documentation` section with links to proposals, architecture decisions, and contributing guide
- **CONTRIBUTING.md**: New file with cross-cutting decision policy requiring Platform-Docs recording before implementation

Part of the org-wide documentation standardization effort.